### PR TITLE
Expose Reading List item UUID

### DIFF
--- a/GLSReadingList.m
+++ b/GLSReadingList.m
@@ -46,6 +46,7 @@ static GLSReadingList *sharedReadingList;
 			GLSReadingListItem *unreadItem = [[GLSReadingListItem alloc] init];
 			unreadItem.title = bookmark[@"URIDictionary"][@"title"];
 			unreadItem.URL = [NSURL URLWithString:bookmark[@"URLString"]];
+			unreadItem.UUID = bookmark[@"WebBookmarkUUID"];
 			[unreadItems addObject:unreadItem];
 		}
 	}

--- a/GLSReadingListItem.h
+++ b/GLSReadingListItem.h
@@ -12,5 +12,6 @@
 
 @property NSString *title;
 @property NSURL *URL;
+@property NSString *UUID;
 
 @end


### PR DESCRIPTION
This is useful when wanting to open Reading List archives from `~/Library/Safari/ReadingListArchives` since they are each in a directory specified by their UUID.
